### PR TITLE
Add weak–strong titration tests

### DIFF
--- a/src/__tests__/weakStrongGeneric.test.ts
+++ b/src/__tests__/weakStrongGeneric.test.ts
@@ -6,21 +6,29 @@ const NaOH    = reagents.find(r => r.id === "naoh")!;
 const Ammonia = reagents.find(r => r.id === "nh3")!;
 const HCl     = reagents.find(r => r.id === "hcl")!;
 
-describe("weak–strong generic", () => {
-  test("ácido fraco titulado por base forte", () => {
+describe("weak–strong titration engine", () => {
+  test("ácido fraco (analito) titulado por base forte (titrante)", () => {
     const pH = calcPHWeakStrongGeneric({
-      analyte: Acetic,  cAnalyte: 0.1, vAnalyte: 0.05,
-      titrant: NaOH,    cTitrant: 0.1, vTitrant: 0.04
+      analyte: Acetic, cAnalyte: 0.1, vAnalyte: 0.05,
+      titrant: NaOH,  cTitrant: 0.1, vTitrant: 0.04
     });
-    expect(pH).toBeCloseTo(5.347, 2);
+    expect(pH).toBeCloseTo(5.34, 2);
   });
 
-  test("base fraca titulada por ácido forte", () => {
+  test("base fraca (analito) titulada por ácido forte (titrante)", () => {
     const pH = calcPHWeakStrongGeneric({
       analyte: Ammonia, cAnalyte: 0.1, vAnalyte: 0.05,
-      titrant: HCl,     cTitrant: 0.1, vTitrant: 0.04
+      titrant: HCl,    cTitrant: 0.1, vTitrant: 0.04
     });
-    expect(pH).toBeCloseTo(8.653, 2);
+    expect(pH).toBeCloseTo(8.65, 2);
+  });
+
+  test("ponto de equivalência ácido fraco × base forte", () => {
+    const pH = calcPHWeakStrongGeneric({
+      analyte: Acetic, cAnalyte: 0.1, vAnalyte: 0.05,
+      titrant: NaOH,  cTitrant: 0.1, vTitrant: 0.05
+    });
+    expect(pH).toBeCloseTo(8.72, 2);
   });
 });
 


### PR DESCRIPTION
## Summary
- add additional tests for weak/strong titration scenarios

## Testing
- `npm install` *(fails: jest not found due to network restrictions)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d2896990832b867c127051d5ca39